### PR TITLE
#24 Allow bucket name prefix gs://

### DIFF
--- a/resources/api/mint-api.yaml
+++ b/resources/api/mint-api.yaml
@@ -333,7 +333,7 @@ definitions:
         items:
           type: string
           example: example-org-stups-mint
-          pattern: "^[a-z0-9][a-z0-9-.]{1,61}[a-z0-9]$"
+          pattern: "^(gs://)?[a-z0-9][a-z0-9-.]{1,61}[a-z0-9]$"
       scopes:
         type: array
         description: |


### PR DESCRIPTION
This makes it possible to add google cloud storage buckets using the
schema `gs://`.

Close #24
