### PR TITLE
#33: Allow multiple redirect urls

### DIFF
--- a/resources/api/mint-api.yaml
+++ b/resources/api/mint-api.yaml
@@ -170,6 +170,14 @@ paths:
                   Which redirect URL is considered valid during the OAuth 2.0 implicit flow. Invalid redirect URLS are
                   not permitted
                 example: https://yourturn.stups.example.org
+              redirect_urls:
+                type: array
+                description: |
+                  Which redirect URLs are considered valid during the OAuth 2.0 implicit flow. Invalid redirect URLs are
+                  not permitted
+                items:
+                  type: string
+                  example: https://yourturn.stups.example.org
               is_client_confidential:
                 type: boolean
                 description: |
@@ -313,10 +321,19 @@ definitions:
       redirect_url:
         type: string
         description: |
-          Which redirect URL is considered valid during the OAuth 2.0 implicit flow. Invalid redirect URLS are
+          Which redirect URL is considered valid during the OAuth 2.0 implicit flow. Invalid redirect URLs are
           not permitted
         example: https://yourturn.stups.example.org
         pattern: "^https:\\/\\/.*$"
+      redirect_urls:
+        type: array
+        description: |
+          Which redirect URLs are considered valid during the OAuth 2.0 implicit flow. Invalid redirect URLs are
+          not permitted
+        items:
+          type: string
+          example: https://yourturn.stups.example.org
+          pattern: "^https:\\/\\/.*$"
       is_client_confidential:
         type: boolean
         description: |

--- a/resources/api/mint-api.yaml
+++ b/resources/api/mint-api.yaml
@@ -324,7 +324,7 @@ definitions:
           Which redirect URL is considered valid during the OAuth 2.0 implicit flow. Invalid redirect URLs are
           not permitted
         example: https://yourturn.stups.example.org
-        pattern: "^https:\\/\\/.*$"
+        pattern: "^(https:\\/\\/.*|http:\\/\\/localhost(\\/.*)?)$"
       redirect_urls:
         type: array
         description: |
@@ -333,7 +333,7 @@ definitions:
         items:
           type: string
           example: https://yourturn.stups.example.org
-          pattern: "^https:\\/\\/.*$"
+          pattern: "^(https:\\/\\/.*|http:\\/\\/localhost(\\/.*)?)$"
       is_client_confidential:
         type: boolean
         description: |

--- a/resources/db/migration/V4__Allow_multiple_redirect_urls.sql
+++ b/resources/db/migration/V4__Allow_multiple_redirect_urls.sql
@@ -1,0 +1,2 @@
+ALTER TABLE zm_data.application
+ ADD COLUMN a_redirect_urls TEXT;

--- a/resources/db/mint.sql
+++ b/resources/db/mint.sql
@@ -27,12 +27,13 @@ SELECT DISTINCT
 
 -- name: create-application!
 INSERT INTO zm_data.application
-            (a_id, a_redirect_url, a_is_client_confidential, a_username, a_s3_buckets, a_last_modified)
-     VALUES (:application_id, :redirect_url, :is_client_confidential, :username, :s3_buckets, now());
+            (a_id, a_redirect_url, a_redirect_urls, a_is_client_confidential, a_username, a_s3_buckets, a_last_modified)
+     VALUES (:application_id, :redirect_url, :redirect_urls, :is_client_confidential, :username, :s3_buckets, now());
 
 -- name: read-application
 SELECT a_id,
        a_redirect_url,
+       a_redirect_urls,
        a_username,
        a_client_id,
        a_last_password_rotation,
@@ -50,6 +51,7 @@ SELECT a_id,
 -- name: update-application!
 UPDATE zm_data.application
    SET a_redirect_url = COALESCE(:redirect_url, a_redirect_url),
+       a_redirect_urls = COALESCE(:redirect_urls, a_redirect_urls),
        a_s3_buckets = COALESCE(:s3_buckets, a_s3_buckets),
        a_is_client_confidential = COALESCE(:is_client_confidential, a_is_client_confidential),
        a_last_modified = now()

--- a/src/org/zalando/stups/mint/storage/api.clj
+++ b/src/org/zalando/stups/mint/storage/api.clj
@@ -53,7 +53,7 @@
                (fn [[k v]] [(remove-prefix k) v])
                m))))
 
-(defn- parse-s3-buckets
+(defn- parse-set
   "Splits a comma-separated string into a sorted set"
   [string]
   (if string
@@ -73,11 +73,12 @@
   (when-first [row (sql/cmd-read-application {:application_id application_id} {:connection db})]
     (-> row
         strip-prefix
-        (update-in [:s3_buckets] parse-s3-buckets)
+        (update-in [:s3_buckets] parse-set)
         (update-in [:last_synced] from-sql-time)
         (update-in [:last_modified] from-sql-time)
         (update-in [:last_client_rotation] from-sql-time)
         (update-in [:last_password_rotation] from-sql-time)
+        (update-in [:redirect_urls] parse-set)
         (assoc :scopes (load-scopes application_id db)))))
 
 (defn read-applications

--- a/src/org/zalando/stups/mint/storage/api.clj
+++ b/src/org/zalando/stups/mint/storage/api.clj
@@ -114,6 +114,7 @@
                                 :has_problems
                                 :message
                                 :redirect_url
+                                :redirect_urls
                                 :is_client_confidential
                                 :s3_errors
                                 :s3_buckets
@@ -214,6 +215,7 @@
           [connection db]
           ; check app base information
           (let [db-app (load-application application_id db)
+                new-redirect-urls (apply sorted-set (map str/lower-case (:redirect_urls application)))
                 new-s3-buckets (apply sorted-set (:s3_buckets application))
                 prefix (:username-prefix configuration)
                 username (if prefix (str prefix application_id) application_id)]
@@ -221,17 +223,20 @@
             (if db-app
               ; check for update (did anything change?)
               (when-not (and (= (:redirect_url db-app) (:redirect_url application))
+                             (= (:redirect_urls db-app) new-redirect-urls)
                              (= (:is_client_confidential db-app) (:is_client_confidential application))
                              (= (:s3_buckets db-app) new-s3-buckets)
                              (= (:scopes db-app) new-scopes))
                 (sql/cmd-update-application! {:application_id         application_id
                                           :redirect_url           (:redirect_url application)
+                                          :redirect_urls          (str/join "," new-redirect-urls)
                                           :is_client_confidential (:is_client_confidential application)
                                           :s3_buckets             (str/join "," new-s3-buckets)}
                                          {:connection connection}))
               ; create new app
               (sql/cmd-create-application! {:application_id         application_id
                                         :redirect_url           (:redirect_url application)
+                                        :redirect_urls          (str/join "," new-redirect-urls)
                                         :is_client_confidential (:is_client_confidential application)
                                         :s3_buckets             (str/join "," new-s3-buckets)
                                         :username               username}


### PR DESCRIPTION
The following changes done in this PR:

- a new column `a_redirect_urls`, has been add to the `application` table to store a list of redirect URLs
- a new property `redirect_urls` has been added to the Swagger API description
- made changes to the code which stores and retrieves application data
- changed regular expressions for `redirect_url` and `redirect_urls` to accept `http` scheme for `localhost`